### PR TITLE
created singlestore-proxy from mysql-proxy

### DIFF
--- a/drizzle-orm/src/singlestore-proxy/driver.ts
+++ b/drizzle-orm/src/singlestore-proxy/driver.ts
@@ -1,0 +1,54 @@
+import { DefaultLogger } from '~/logger.ts';
+import {
+	createTableRelationsHelpers,
+	extractTablesRelationalConfig,
+	type RelationalSchemaConfig,
+	type TablesRelationalConfig,
+} from '~/relations.ts';
+import { SingleStoreDatabase } from '~/singlestore-core/db.ts';
+import { SingleStoreDialect } from '~/singlestore-core/dialect.ts';
+import type { DrizzleConfig } from '~/utils.ts';
+import {
+	type SingleStoreRemotePreparedQueryHKT,
+	type SingleStoreRemoteQueryResultHKT,
+	SingleStoreRemoteSession,
+} from './session.ts';
+
+export type SingleStoreRemoteDatabase<
+	TSchema extends Record<string, unknown> = Record<string, never>,
+> = SingleStoreDatabase<SingleStoreRemoteQueryResultHKT, SingleStoreRemotePreparedQueryHKT, TSchema>;
+
+export type RemoteCallback = (
+	sql: string,
+	params: any[],
+	method: 'all' | 'execute',
+) => Promise<{ rows: any[]; insertId?: number; affectedRows?: number }>;
+
+export function drizzle<TSchema extends Record<string, unknown> = Record<string, never>>(
+	callback: RemoteCallback,
+	config: DrizzleConfig<TSchema> = {},
+): SingleStoreRemoteDatabase<TSchema> {
+	const dialect = new SingleStoreDialect();
+	let logger;
+	if (config.logger === true) {
+		logger = new DefaultLogger();
+	} else if (config.logger !== false) {
+		logger = config.logger;
+	}
+
+	let schema: RelationalSchemaConfig<TablesRelationalConfig> | undefined;
+	if (config.schema) {
+		const tablesConfig = extractTablesRelationalConfig(
+			config.schema,
+			createTableRelationsHelpers,
+		);
+		schema = {
+			fullSchema: config.schema,
+			schema: tablesConfig.tables,
+			tableNamesMap: tablesConfig.tableNamesMap,
+		};
+	}
+
+	const session = new SingleStoreRemoteSession(callback, dialect, schema, { logger });
+	return new SingleStoreDatabase(dialect, session, schema, 'default') as SingleStoreRemoteDatabase<TSchema>;
+}

--- a/drizzle-orm/src/singlestore-proxy/index.ts
+++ b/drizzle-orm/src/singlestore-proxy/index.ts
@@ -1,0 +1,2 @@
+export * from './driver.ts';
+export * from './session.ts';

--- a/drizzle-orm/src/singlestore-proxy/migrator.ts
+++ b/drizzle-orm/src/singlestore-proxy/migrator.ts
@@ -1,0 +1,52 @@
+import type { MigrationConfig } from '~/migrator.ts';
+import { readMigrationFiles } from '~/migrator.ts';
+import { sql } from '~/sql/sql.ts';
+import type { SingleStoreRemoteDatabase } from './driver.ts';
+
+export type ProxyMigrator = (migrationQueries: string[]) => Promise<void>;
+
+export async function migrate<TSchema extends Record<string, unknown>>(
+	db: SingleStoreRemoteDatabase<TSchema>,
+	callback: ProxyMigrator,
+	config: MigrationConfig,
+) {
+	const migrations = readMigrationFiles(config);
+
+	const migrationsTable = config.migrationsTable ?? '__drizzle_migrations';
+	const migrationTableCreate = sql`
+		create table if not exists ${sql.identifier(migrationsTable)} (
+			id serial primary key,
+			hash text not null,
+			created_at bigint
+		)
+	`;
+	await db.execute(migrationTableCreate);
+
+	const dbMigrations = await db.select({
+		id: sql.raw('id'),
+		hash: sql.raw('hash'),
+		created_at: sql.raw('created_at'),
+	}).from(sql.identifier(migrationsTable).getSQL()).orderBy(
+		sql.raw('created_at desc'),
+	).limit(1);
+
+	const lastDbMigration = dbMigrations[0];
+
+	const queriesToRun: string[] = [];
+
+	for (const migration of migrations) {
+		if (
+			!lastDbMigration
+			|| Number(lastDbMigration.created_at) < migration.folderMillis
+		) {
+			queriesToRun.push(
+				...migration.sql,
+				`insert into ${
+					sql.identifier(migrationsTable).value
+				} (\`hash\`, \`created_at\`) values('${migration.hash}', '${migration.folderMillis}')`,
+			);
+		}
+	}
+
+	await callback(queriesToRun);
+}

--- a/drizzle-orm/src/singlestore-proxy/session.ts
+++ b/drizzle-orm/src/singlestore-proxy/session.ts
@@ -1,0 +1,178 @@
+import type { FieldPacket, ResultSetHeader } from 'mysql2/promise';
+import { Column } from '~/column.ts';
+import { entityKind, is } from '~/entity.ts';
+import type { Logger } from '~/logger.ts';
+import { NoopLogger } from '~/logger.ts';
+import type { RelationalSchemaConfig, TablesRelationalConfig } from '~/relations.ts';
+import type { SingleStoreDialect } from '~/singlestore-core/dialect.ts';
+import { SingleStoreTransaction } from '~/singlestore-core/index.ts';
+import type { SelectedFieldsOrdered } from '~/singlestore-core/query-builders/select.types.ts';
+import type {
+	PreparedQueryKind,
+	SingleStorePreparedQueryConfig,
+	SingleStorePreparedQueryHKT,
+	SingleStoreQueryResultHKT,
+	SingleStoreTransactionConfig,
+} from '~/singlestore-core/session.ts';
+import { SingleStorePreparedQuery as PreparedQueryBase, SingleStoreSession } from '~/singlestore-core/session.ts';
+import { fillPlaceholders } from '~/sql/sql.ts';
+import type { Query, SQL } from '~/sql/sql.ts';
+import { type Assume, mapResultRow } from '~/utils.ts';
+import type { RemoteCallback } from './driver.ts';
+
+export type SingleStoreRawQueryResult = [ResultSetHeader, FieldPacket[]];
+
+export interface SingleStoreRemoteSessionOptions {
+	logger?: Logger;
+}
+
+export class SingleStoreRemoteSession<
+	TFullSchema extends Record<string, unknown>,
+	TSchema extends TablesRelationalConfig,
+> extends SingleStoreSession<SingleStoreRemoteQueryResultHKT, SingleStoreRemotePreparedQueryHKT, TFullSchema, TSchema> {
+	static readonly [entityKind]: string = 'SingleStoreRemoteSession';
+
+	private logger: Logger;
+
+	constructor(
+		private client: RemoteCallback,
+		dialect: SingleStoreDialect,
+		private schema: RelationalSchemaConfig<TSchema> | undefined,
+		options: SingleStoreRemoteSessionOptions,
+	) {
+		super(dialect);
+		this.logger = options.logger ?? new NoopLogger();
+	}
+
+	prepareQuery<T extends SingleStorePreparedQueryConfig>(
+		query: Query,
+		fields: SelectedFieldsOrdered | undefined,
+		customResultMapper?: (rows: unknown[][]) => T['execute'],
+		generatedIds?: Record<string, unknown>[],
+		returningIds?: SelectedFieldsOrdered,
+	): PreparedQueryKind<SingleStoreRemotePreparedQueryHKT, T> {
+		return new PreparedQuery(
+			this.client,
+			query.sql,
+			query.params,
+			this.logger,
+			fields,
+			customResultMapper,
+			generatedIds,
+			returningIds,
+		) as PreparedQueryKind<SingleStoreRemotePreparedQueryHKT, T>;
+	}
+
+	override all<T = unknown>(query: SQL): Promise<T[]> {
+		const querySql = this.dialect.sqlToQuery(query);
+		this.logger.logQuery(querySql.sql, querySql.params);
+		return this.client(querySql.sql, querySql.params, 'all').then(({ rows }) => rows) as Promise<T[]>;
+	}
+
+	override async transaction<T>(
+		_transaction: (tx: SingleStoreProxyTransaction<TFullSchema, TSchema>) => Promise<T>,
+		_config?: SingleStoreTransactionConfig,
+	): Promise<T> {
+		throw new Error('Transactions are not supported by the SingleStore Proxy driver');
+	}
+}
+
+export class SingleStoreProxyTransaction<
+	TFullSchema extends Record<string, unknown>,
+	TSchema extends TablesRelationalConfig,
+> extends SingleStoreTransaction<
+	SingleStoreRemoteQueryResultHKT,
+	SingleStoreRemotePreparedQueryHKT,
+	TFullSchema,
+	TSchema
+> {
+	static readonly [entityKind]: string = 'SingleStoreProxyTransaction';
+
+	override async transaction<T>(
+		_transaction: (tx: SingleStoreProxyTransaction<TFullSchema, TSchema>) => Promise<T>,
+	): Promise<T> {
+		throw new Error('Transactions are not supported by the SingleStore Proxy driver');
+	}
+}
+
+export class PreparedQuery<T extends SingleStorePreparedQueryConfig> extends PreparedQueryBase<T> {
+	static readonly [entityKind]: string = 'SingleStoreProxyPreparedQuery';
+
+	constructor(
+		private client: RemoteCallback,
+		private queryString: string,
+		private params: unknown[],
+		private logger: Logger,
+		private fields: SelectedFieldsOrdered | undefined,
+		private customResultMapper?: (rows: unknown[][]) => T['execute'],
+		// Keys that were used in $default and the value that was generated for them
+		private generatedIds?: Record<string, unknown>[],
+		// Keys that should be returned, it has the column with all properries + key from object
+		private returningIds?: SelectedFieldsOrdered,
+	) {
+		super();
+	}
+
+	async execute(placeholderValues: Record<string, unknown> | undefined = {}): Promise<T['execute']> {
+		const params = fillPlaceholders(this.params, placeholderValues);
+
+		const { fields, client, queryString, logger, joinsNotNullableMap, customResultMapper, returningIds, generatedIds } =
+			this;
+
+		logger.logQuery(queryString, params);
+
+		if (!fields && !customResultMapper) {
+			const { rows: data } = await client(queryString, params, 'execute');
+
+			const insertId = data[0].insertId as number;
+			const affectedRows = data[0].affectedRows;
+
+			if (returningIds) {
+				const returningResponse = [];
+				let j = 0;
+				for (let i = insertId; i < insertId + affectedRows; i++) {
+					for (const column of returningIds) {
+						const key = returningIds[0]!.path[0]!;
+						if (is(column.field, Column)) {
+							// @ts-ignore
+							if (column.field.primary && column.field.autoIncrement) {
+								returningResponse.push({ [key]: i });
+							}
+							if (column.field.defaultFn && generatedIds) {
+								// generatedIds[rowIdx][key]
+								returningResponse.push({ [key]: generatedIds[j]![key] });
+							}
+						}
+					}
+					j++;
+				}
+
+				return returningResponse;
+			}
+
+			return data;
+		}
+
+		const { rows } = await client(queryString, params, 'all');
+
+		if (customResultMapper) {
+			return customResultMapper(rows);
+		}
+
+		return rows.map((row) => mapResultRow<T['execute']>(fields!, row, joinsNotNullableMap));
+	}
+
+	override iterator(
+		_placeholderValues: Record<string, unknown> = {},
+	): AsyncGenerator<T['iterator']> {
+		throw new Error('Streaming is not supported by the SingleStore Proxy driver');
+	}
+}
+
+export interface SingleStoreRemoteQueryResultHKT extends SingleStoreQueryResultHKT {
+	type: SingleStoreRawQueryResult;
+}
+
+export interface SingleStoreRemotePreparedQueryHKT extends SingleStorePreparedQueryHKT {
+	type: PreparedQuery<Assume<this['config'], SingleStorePreparedQueryConfig>>;
+}


### PR DESCRIPTION
The mysql-proxy is a mysql connector used in mysql integration tests:
[summer-hackathon-s2-drizzle-orm/integration-tests/tests/mysql/mysql-proxy.test.ts at main · singlestore-labs/summer-hackathon-s2-drizzle-orm](https://github.com/singlestore-labs/summer-hackathon-s2-drizzle-orm/blob/main/integration-tests/tests/mysql/mysql-proxy.test.ts) 
[summer-hackathon-s2-drizzle-orm/integration-tests/tests/mysql/mysql-common.ts at main · singlestore-labs/summer-hackathon-s2-drizzle-orm](https://github.com/singlestore-labs/summer-hackathon-s2-drizzle-orm/blob/main/integration-tests/tests/mysql/mysql-common.ts#L82) 

Copied the [mysql-proxy](https://github.com/singlestore-labs/summer-hackathon-s2-drizzle-orm/tree/main/drizzle-orm/src/mysql-proxy) directory and renamed it to singlestore-proxy, as well as change every MySql reference to SingleStore.

There is no need to change the logic because the mysql-proxy is a driver such as the mysql2