### PR TITLE
removed nested transaction tests

### DIFF
--- a/integration-tests/tests/singlestore/singlestore-common.ts
+++ b/integration-tests/tests/singlestore/singlestore-common.ts
@@ -2177,67 +2177,6 @@ export function tests(driver?: string) {
 			await db.execute(sql`drop table ${users}`);
 		});
 
-		test('nested transaction', async (ctx) => {
-			const { db } = ctx.singlestore;
-
-			const users = singlestoreTable('users_nested_transactions', {
-				id: serial('id').primaryKey(),
-				balance: int('balance').notNull(),
-			});
-
-			await db.execute(sql`drop table if exists ${users}`);
-
-			await db.execute(
-				sql`create table users_nested_transactions (id serial not null primary key, balance int not null)`,
-			);
-
-			await db.transaction(async (tx) => {
-				await tx.insert(users).values({ id: 1, balance: 100 });
-
-				await tx.transaction(async (tx) => {
-					await tx.update(users).set({ balance: 200 });
-				});
-			});
-
-			const result = await db.select().from(users);
-
-			expect(result).toEqual([{ id: 1, balance: 200 }]);
-
-			await db.execute(sql`drop table ${users}`);
-		});
-
-		test('nested transaction rollback', async (ctx) => {
-			const { db } = ctx.singlestore;
-
-			const users = singlestoreTable('users_nested_transactions_rollback', {
-				id: serial('id').primaryKey(),
-				balance: int('balance').notNull(),
-			});
-
-			await db.execute(sql`drop table if exists ${users}`);
-
-			await db.execute(
-				sql`create table users_nested_transactions_rollback (id serial not null primary key, balance int not null)`,
-			);
-
-			await db.transaction(async (tx) => {
-				await tx.insert(users).values({ id: 1, balance: 100 });
-
-				await expect((async () => {
-					await tx.transaction(async (tx) => {
-						await tx.update(users).set({ balance: 200 });
-						tx.rollback();
-					});
-				})()).rejects.toThrowError(TransactionRollbackError);
-			});
-
-			const result = await db.select().from(users);
-
-			expect(result).toEqual([{ id: 1, balance: 100 }]);
-
-			await db.execute(sql`drop table ${users}`);
-		});
-
 		test('join subquery with join', async (ctx) => {
 			const { db } = ctx.singlestore;
 

--- a/integration-tests/tests/singlestore/singlestore-prefixed.test.ts
+++ b/integration-tests/tests/singlestore/singlestore-prefixed.test.ts
@@ -1342,63 +1342,6 @@ test('transaction rollback', async () => {
 	expect(result).toEqual([]);
 });
 
-test('nested transaction', async () => {
-	const users = singlestoreTable('users_nested_transactions', {
-		id: serial('id').primaryKey(),
-		balance: int('balance').notNull(),
-	});
-
-	await db.execute(sql`drop table if exists ${users}`);
-
-	await db.execute(
-		sql`create table ${users} (id serial not null primary key, balance int not null)`,
-	);
-
-	await db.transaction(async (tx) => {
-		await tx.insert(users).values({ balance: 100 });
-
-		await tx.transaction(async (tx) => {
-			await tx.update(users).set({ balance: 200 });
-		});
-	});
-
-	const result = await db.select().from(users);
-
-	await db.execute(sql`drop table ${users}`);
-
-	expect(result).toEqual([{ id: 1, balance: 200 }]);
-});
-
-test('nested transaction rollback', async () => {
-	const users = singlestoreTable('users_nested_transactions_rollback', {
-		id: serial('id').primaryKey(),
-		balance: int('balance').notNull(),
-	});
-
-	await db.execute(sql`drop table if exists ${users}`);
-
-	await db.execute(
-		sql`create table ${users} (id serial not null primary key, balance int not null)`,
-	);
-
-	await db.transaction(async (tx) => {
-		await tx.insert(users).values({ id: 1, balance: 100 });
-
-		await expect((async () => {
-			await tx.transaction(async (tx) => {
-				await tx.update(users).set({ balance: 200 });
-				tx.rollback();
-			});
-		})()).rejects.toThrowError(TransactionRollbackError);
-	});
-
-	const result = await db.select().from(users);
-
-	await db.execute(sql`drop table ${users}`);
-
-	expect(result).toEqual([{ id: 1, balance: 100 }]);
-});
-
 test('join subquery with join', async () => {
 	const internalStaff = singlestoreTable('internal_staff', {
 		userId: int('user_id').notNull(),


### PR DESCRIPTION
Removes nested transactions from the singlestore test suite as singlestore officially doesn't support nested transactions:

https://docs.singlestore.com/cloud/reference/sql-reference/procedural-sql-reference/transactions-in-stored-procedures/