### PR TITLE
Bugfix/remove isolationlevel tests

### DIFF
--- a/drizzle-orm/src/singlestore-core/session.ts
+++ b/drizzle-orm/src/singlestore-core/session.ts
@@ -56,7 +56,6 @@ export abstract class SingleStorePreparedQuery<T extends SingleStorePreparedQuer
 export interface SingleStoreTransactionConfig {
 	withConsistentSnapshot?: boolean;
 	accessMode?: 'read only' | 'read write';
-	isolationLevel: 'read uncommitted' | 'read committed' | 'repeatable read' | 'serializable';
 }
 
 export abstract class SingleStoreSession<
@@ -93,16 +92,6 @@ export abstract class SingleStoreSession<
 		transaction: (tx: SingleStoreTransaction<TQueryResult, TPreparedQueryHKT, TFullSchema, TSchema>) => Promise<T>,
 		config?: SingleStoreTransactionConfig,
 	): Promise<T>;
-
-	protected getSetTransactionSQL(config: SingleStoreTransactionConfig): SQL | undefined {
-		const parts: string[] = [];
-
-		if (config.isolationLevel) {
-			parts.push(`isolation level ${config.isolationLevel}`);
-		}
-
-		return parts.length ? sql.join(['set transaction ', parts.join(' ')]) : undefined;
-	}
 
 	protected getStartTransactionSQL(config: SingleStoreTransactionConfig): SQL | undefined {
 		const parts: string[] = [];

--- a/drizzle-orm/src/singlestore-core/session.ts
+++ b/drizzle-orm/src/singlestore-core/session.ts
@@ -53,6 +53,7 @@ export abstract class SingleStorePreparedQuery<T extends SingleStorePreparedQuer
 	abstract iterator(placeholderValues?: Record<string, unknown>): AsyncGenerator<T['iterator']>;
 }
 
+// In SingleStore, there is no need to explicitly set the isolation level, since READ COMMITTED is the only isolation level supported and is set by default for all transactions
 export interface SingleStoreTransactionConfig {
 	withConsistentSnapshot?: boolean;
 	accessMode?: 'read only' | 'read write';

--- a/drizzle-orm/src/singlestore/session.ts
+++ b/drizzle-orm/src/singlestore/session.ts
@@ -273,10 +273,6 @@ export class SingleStore2Session<
 			this.mode,
 		);
 		if (config) {
-			const setTransactionConfigSql = this.getSetTransactionSQL(config);
-			if (setTransactionConfigSql) {
-				await tx.execute(setTransactionConfigSql);
-			}
 			const startTransactionSql = this.getStartTransactionSQL(config);
 			await (startTransactionSql ? tx.execute(startTransactionSql) : tx.execute(sql`begin`));
 		} else {

--- a/integration-tests/tests/singlestore/singlestore-common.ts
+++ b/integration-tests/tests/singlestore/singlestore-common.ts
@@ -2790,13 +2790,13 @@ export function tests(driver?: string) {
 
 			// multiple results possible as a result of the filters >= 5 and ==7 because singlestore doesn't guarantee order
 			// dynamically validate results
-			const hasValidEntry = (entry: { id: number; name: string; }) => {
+			const hasValidEntry = (entry: { id: number; name: string }) => {
 				if (entry.id === 1) return entry.name === 'John';
 				if (entry.id > 1 && entry.id < 5) return entry.name === 'Tampa' || entry.name === 'London';
 				if (entry.id >= 5 && entry.id !== 7) return true; // Accept any entry with id >= 5 and not 7
 				return false;
 			};
-		
+
 			for (const entry of result) {
 				expect(hasValidEntry(entry)).toBe(true);
 			}

--- a/integration-tests/tests/singlestore/singlestore-common.ts
+++ b/integration-tests/tests/singlestore/singlestore-common.ts
@@ -2098,45 +2098,6 @@ export function tests(driver?: string) {
 			await db.execute(sql`drop table ${products}`);
 		});
 
-		test('transaction with options (set isolationLevel)', async (ctx) => {
-			const { db } = ctx.singlestore;
-
-			const users = singlestoreTable('users_transactions', {
-				id: serial('id').primaryKey(),
-				balance: int('balance').notNull(),
-			});
-			const products = singlestoreTable('products_transactions', {
-				id: serial('id').primaryKey(),
-				price: int('price').notNull(),
-				stock: int('stock').notNull(),
-			});
-
-			await db.execute(sql`drop table if exists ${users}`);
-			await db.execute(sql`drop table if exists ${products}`);
-
-			await db.execute(sql`create table users_transactions (id serial not null primary key, balance int not null)`);
-			await db.execute(
-				sql`create table products_transactions (id serial not null primary key, price int not null, stock int not null)`,
-			);
-
-			const [{ insertId: userId }] = await db.insert(users).values({ id: 1, balance: 100 });
-			const user = await db.select().from(users).where(eq(users.id, userId)).then((rows) => rows[0]!);
-			const [{ insertId: productId }] = await db.insert(products).values({ id: 1, price: 10, stock: 10 });
-			const product = await db.select().from(products).where(eq(products.id, productId)).then((rows) => rows[0]!);
-
-			await db.transaction(async (tx) => {
-				await tx.update(users).set({ balance: user.balance - product.price }).where(eq(users.id, user.id));
-				await tx.update(products).set({ stock: product.stock - 1 }).where(eq(products.id, product.id));
-			}, { isolationLevel: 'serializable' });
-
-			const result = await db.select().from(users);
-
-			expect(result).toEqual([{ id: 1, balance: 90 }]);
-
-			await db.execute(sql`drop table ${users}`);
-			await db.execute(sql`drop table ${products}`);
-		});
-
 		test('transaction rollback', async (ctx) => {
 			const { db } = ctx.singlestore;
 

--- a/integration-tests/tests/singlestore/singlestore-common.ts
+++ b/integration-tests/tests/singlestore/singlestore-common.ts
@@ -2797,9 +2797,9 @@ export function tests(driver?: string) {
 				return false;
 			};
 		
-			result.forEach(entry => {
+			for (const entry of result) {
 				expect(hasValidEntry(entry)).toBe(true);
-			});
+			}
 
 			await expect((async () => {
 				union(

--- a/integration-tests/tests/singlestore/singlestore-custom.test.ts
+++ b/integration-tests/tests/singlestore/singlestore-custom.test.ts
@@ -54,7 +54,7 @@ beforeAll(async () => {
 			client?.end();
 		},
 	});
-	
+
 	await client.query(`CREATE DATABASE IF NOT EXISTS drizzle;`);
 	await client.changeUser({ database: 'drizzle' });
 	db = drizzle(client, { logger: ENABLE_LOGGING });


### PR DESCRIPTION
Removed isolationlevel config and tests as singlestore only supports one isolationlevel:


https://docs.singlestore.com/cloud/getting-started-with-singlestore-helios/about-singlestore-helios/singlestore-helios-faqs/durability/